### PR TITLE
Consider only latest ref version if multiple

### DIFF
--- a/.github/workflows/pr-build-and-test.yml
+++ b/.github/workflows/pr-build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DotnetRefScan.Tests/DotnetRefScan.Tests.csproj
+++ b/DotnetRefScan.Tests/DotnetRefScan.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/DotnetRefScan.Tests/DotnetRefScan.Tests.csproj
+++ b/DotnetRefScan.Tests/DotnetRefScan.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DotnetRefScan.Tests/TestData/TestLicense1.md
+++ b/DotnetRefScan.Tests/TestData/TestLicense1.md
@@ -2,7 +2,7 @@
 
 License text...
 
-### Copyright (C) DotnetRefScan 2023.
+### Copyright (C) DotnetRefScan 2025.
 ### All rights reserved.
 ### Written by DotnetRefScan.
 

--- a/DotnetRefScan.Tests/TestData/TestLicense2.md
+++ b/DotnetRefScan.Tests/TestData/TestLicense2.md
@@ -2,7 +2,7 @@
 
 License text...
 
-### Copyright (C) DotnetRefScan 2023.
+### Copyright (C) DotnetRefScan 2025.
 ### All rights reserved.
 ### Written by DotnetRefScan.
 
@@ -11,9 +11,10 @@ License text...
 | Library                           | Version | Source     | Copyright                         | License type            | License or project link         |
 |-----------------------------------|---------|------------|-----------------------------------|-------------------------|---------------------------------|
 | package1                          | 1.2.3   | jsdelivr   |                                   |                         |                                 |
+| package1                          | 4.5.6   | cdnjs      |                                   |                         |                                 |
 | package2                          | 4.5.6   | cdnjs      |                                   |                         |                                 |
 | package3                          | 7.8.9   | jsdelivr   |                                   |                         |                                 |
-| CliWrap                           | 3.6.4   | NuGet      |                                   |                         |                                 |
-| coverlet.collector                | 6.0.0   | NuGet      |                                   |                         |                                 |
+| CliWrap                           | 3.7.0   | NuGet      |                                   |                         |                                 |
+| coverlet.collector                | 6.0.3   | NuGet      |                                   |                         |                                 |
 | Newtonsoft.Json                   | 13.0.3  | NuGet      |                                   |                         |                                 |
 | RedundantPackage                  | x.x.x   | NuGet      |                                   |                         |                                 |

--- a/DotnetRefScan.Tests/TestData/libman.json
+++ b/DotnetRefScan.Tests/TestData/libman.json
@@ -4,12 +4,21 @@
 	"libraries": [
 		{
 			"provider": "jsdelivr",
-			"library": "package1@1.2.3",
+			"library": "package1@1.2.1",
 			"destination": "1"
 		},
 		{
-			"library": "package2@4.5.6",
+			"provider": "jsdelivr",
+			"library": "package1@1.2.3",
 			"destination": "2"
+		},
+		{
+			"library": "package1@4.5.6",
+			"destination": "3"
+		},
+		{
+			"library": "package2@4.5.6",
+			"destination": "4"
 		}
 	]
 }

--- a/DotnetRefScan.Tests/UnitTests.cs
+++ b/DotnetRefScan.Tests/UnitTests.cs
@@ -7,7 +7,7 @@ namespace DotnetRefScan.Tests
         private readonly string solutionRootFolder;
         private readonly string testDataFolder;
         private readonly PackageReference packageRefJson = new("Newtonsoft.Json", "13.0.3", "NuGet");
-        private readonly PackageReference packageRefCli = new("CliWrap", "3.6.4", "NuGet");
+        private readonly PackageReference packageRefCli = new("CliWrap", "3.7.0", "NuGet");
 
         public Tests()
         {
@@ -80,8 +80,10 @@ namespace DotnetRefScan.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(references, Is.Not.Null);
-                Assert.That(references, Has.Count.EqualTo(3));
+                Assert.That(references, Has.Count.EqualTo(4));
+                Assert.That(references, Does.Not.Contain(new PackageReference("package1", "1.2.1", "jsdelivr")));
                 Assert.That(references, Does.Contain(new PackageReference("package1", "1.2.3", "jsdelivr")));
+                Assert.That(references, Does.Contain(new PackageReference("package1", "4.5.6", "cdnjs")));
                 Assert.That(references, Does.Contain(new PackageReference("package2", "4.5.6", "cdnjs")));
                 Assert.That(references, Does.Contain(new PackageReference("package3", "7.8.9", "jsdelivr")));
             });
@@ -97,8 +99,10 @@ namespace DotnetRefScan.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(references, Is.Not.Null);
-                Assert.That(references, Has.Count.EqualTo(2));
+                Assert.That(references, Has.Count.EqualTo(3));
+                Assert.That(references, Does.Not.Contain(new PackageReference("package1", "1.2.1", "jsdelivr")));
                 Assert.That(references, Does.Contain(new PackageReference("package1", "1.2.3", "jsdelivr")));
+                Assert.That(references, Does.Contain(new PackageReference("package1", "4.5.6", "cdnjs")));
                 Assert.That(references, Does.Contain(new PackageReference("package2", "4.5.6", "cdnjs")));
                 Assert.That(references, Does.Not.Contain(new PackageReference("package3", "7.8.9", "jsdelivr")));
             });

--- a/DotnetRefScan/DotnetRefScan.csproj
+++ b/DotnetRefScan/DotnetRefScan.csproj
@@ -6,14 +6,14 @@
     <Nullable>enable</Nullable>
     <Product>DotnetRefScan</Product>
     <Authors>Simon Polan</Authors>
-    <Copyright>Copyright © Simon Polan 2023</Copyright>
-    <Version>1.0.2</Version>
+    <Copyright>Copyright © Simon Polan 2025</Copyright>
+    <Version>2.0.0</Version>
     <Description>Reference scanner for Dotnet applications. It loads NuGets and Libman references from your source code.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/simonpolan/DotnetRefScan</PackageProjectUrl>
-	<PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <PackageReleaseNotes>Transitive packages listing bug fixed at CSharpProjectFileUsedReferencesProvider.</PackageReleaseNotes>
+    <PackageReleaseNotes>The library now searches for only the latest version of a specific reference (if multiple versions used in the project) when verifying license.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -26,13 +26,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <None Include="..\README.md" Pack="true" PackagePath="\"/>
-	  <None Include="..\LICENSE" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="CliWrap" Version="3.6.4" />
+    <PackageReference Include="CliWrap" Version="3.7.0" />
   </ItemGroup>
 
 </Project>

--- a/DotnetRefScan/ExtensionMethods.cs
+++ b/DotnetRefScan/ExtensionMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace DotnetRefScan
 {
@@ -36,6 +37,45 @@ namespace DotnetRefScan
                 .ThenBy(r => r.Name)
                 .ThenBy(r => r.Version)
                 .ToList();
+        }
+
+        public static ICollection<T> LatestAndSorted<T>(this ICollection<T> references)
+            where T : PackageReference
+        {
+            int maxDigits = references.GetMaxVersionDigitsCount();
+
+            return references
+                .GroupBy(r => $"{r.Source}-{r.Name}")
+                .Select(r => r.OrderByDescending(v => v.GetVersionNumber(maxDigits)).First())
+                .OrderBy(r => r.Source)
+                .ThenBy(r => r.Name)
+                .ToList();
+        }
+
+        public static long GetVersionNumber(this PackageReference packageReference, int expandToDigits)
+        {
+            string[] parts = packageReference.Version.Split('.');
+            StringBuilder versionString = new StringBuilder();
+            foreach (string part in parts)
+            {
+                if (long.TryParse(part, out long number))
+                {
+                    versionString.Append(number.ToString($"D{expandToDigits}"));
+                }
+            }
+            string version = versionString.ToString();
+            return string.IsNullOrEmpty(version) ? 0 : long.Parse(version);
+        }
+
+        public static int GetMaxVersionDigitsCount<T>(this ICollection<T> references)
+            where T : PackageReference
+        {
+            return references
+                .SelectMany(r => r.Version.Split('.'))
+                .Distinct()
+                .Where(part => long.TryParse(part, out long _))
+                .Select(part => part.Length)
+                .Max();
         }
 
         public static Func<T, bool> Not<T>(this Func<T, bool> predicate)

--- a/DotnetRefScan/RefScan.cs
+++ b/DotnetRefScan/RefScan.cs
@@ -78,7 +78,7 @@ namespace DotnetRefScan
                 }
             }
 
-            return references.DistinctAndSorted();
+            return references.LatestAndSorted();
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace DotnetRefScan
         public async Task<ICollection<PackageReference>> LoadLicenseReferences(string licenseFileName)
         {
             ICollection<PackageReference> references = await LicenseReferencesProvider.LoadReferences(licenseFileName).ConfigureAwait(false);
-            return references.DistinctAndSorted();
+            return references.LatestAndSorted();
         }
 
         /// <summary>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Simon Polan 2023
+Copyright (c) Simon Polan 2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ var licensePackageReferences = await refScan.LoadLicenseReferences("License file
 
 ## Release notes
 
-### 2.0.0
+### 2025-01-14 - 2.0.0
 The library now searches for only the latest version of a specific reference (if multiple versions used in the project) when verifying license.
 
-### 1.0.2
+### 2023/12/06 - 1.0.2
 Initial version of the library
 
 ## License

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ var licensePackageReferences = await refScan.LoadLicenseReferences("License file
 
 ---
 
+## Release notes
+
+### 2.0.0
+The library now searches for only the latest version of a specific reference (if multiple versions used in the project) when verifying license.
+
+### 1.0.2
+Initial version of the library
+
 ## License
 
 This library is released under MIT license. Feel free to use it as your wish.


### PR DESCRIPTION
The library now searches for only the latest version of a specific reference (if multiple versions used in the project) when verifying license.